### PR TITLE
refactor fps, all tests passing

### DIFF
--- a/multicamera_acquisition/acquisition.py
+++ b/multicamera_acquisition/acquisition.py
@@ -36,6 +36,7 @@ class AcquisitionLoop(mp.Process):
         self,
         write_queue,
         display_queue,
+        fps,
         write_queue_depth=None,
         camera_config=None,
         acq_loop_config=None,
@@ -67,6 +68,7 @@ class AcquisitionLoop(mp.Process):
         self.display_queue = display_queue
         self.write_queue_depth = write_queue_depth
         self.camera_config = camera_config
+        self.fps = fps
 
         # Get config
         if acq_loop_config is None:
@@ -122,6 +124,7 @@ class AcquisitionLoop(mp.Process):
         # Then just add the device index to the config and allow the cameras to directly
         # receive a device index.
         cam = get_camera(
+            self.fps,
             brand=self.camera_config["brand"],
             id=self.camera_config["id"],
             name=self.camera_config["name"],
@@ -337,6 +340,7 @@ def refactor_acquire_video(
 
         globals:
             fps: 30
+            arduino_required: False  # since trigger short name is set to continuous
         cameras:
             top:
                 name: top
@@ -394,24 +398,24 @@ def refactor_acquire_video(
     save_config(config_filepath, final_config)
 
     # Find the arduino to be used for triggering
-    # TODO: allow user to specify a port
-    ports = find_serial_ports()
-    found_arduino = False
-    for port in ports:
-        with serial.Serial(port=port, timeout=0.1) as arduino:
-            try:
-                wait_for_serial_confirmation(
-                    arduino, expected_confirmation="Waiting...", seconds_to_wait=2
-                )
-                found_arduino = True
-                break
-            except ValueError:
-                continue
-    if found_arduino is False:
-        raise RuntimeError("Could not find waiting arduino to do triggers!")
-    else:
-        print(f"Using port {port} for arduino.")
-    arduino = serial.Serial(port=port, timeout=1)  #TODO: un-hardcode the timeout
+    if final_config["globals"]["arduino_required"]:
+        ports = find_serial_ports()
+        found_arduino = False
+        for port in ports:
+            with serial.Serial(port=port, timeout=0.1) as arduino:
+                try:
+                    wait_for_serial_confirmation(
+                        arduino, expected_confirmation="Waiting...", seconds_to_wait=2
+                    )
+                    found_arduino = True
+                    break
+                except ValueError:
+                    continue
+        if found_arduino is False:
+            raise RuntimeError("Could not find waiting arduino to do triggers!")
+        else:
+            print(f"Using port {port} for arduino.")
+        arduino = serial.Serial(port=port, timeout=1)  # TODO: un-hardcode the timeout
 
     # Delay recording to allow serial connection to connect
     sleep_duration = 2
@@ -465,6 +469,7 @@ def refactor_acquire_video(
         acquisition_loop = AcquisitionLoop(
             write_queue=write_queue,
             display_queue=None,
+            fps=final_config["globals"]["fps"],
             write_queue_depth=write_queue_depth,
             camera_config=camera_dict,
             acq_loop_config=final_config["acq_loop"],
@@ -489,66 +494,57 @@ def refactor_acquire_video(
         acquisition_loop._continue_from_main_thread()
         acquisition_loop.await_process.wait()
 
-    # Tell the arduino to start recording by sending along the recording parameters
-    fps = final_config["cameras"][camera_name]["fps"]
-    inv_framerate = int(np.round(1e6 / fps, 0))
-    num_cycles = int(recording_duration_s * 30)
-    msg = b"".join(
-        map(
-            packIntAsLong,
-            (
-                num_cycles,
-                inv_framerate,
-            ),
-        )
-    )
-    arduino.write(msg)
+    # If using arduino, start it. Otherwise, just wait for the specified duration.
+    if final_config["globals"]["arduino_required"]:
 
-    # Run acquision
-    try:
-        confirmation = wait_for_serial_confirmation(
-            arduino, expected_confirmation="Start", seconds_to_wait=10
+        # Tell the arduino to start recording by sending along the recording parameters
+        fps = final_config["globals"]["fps"]
+        inv_framerate = int(np.round(1e6 / fps, 0))
+        num_cycles = int(recording_duration_s * 30)
+        msg = b"".join(
+            map(
+                packIntAsLong,
+                (
+                    num_cycles,
+                    inv_framerate,
+                ),
+            )
         )
-    except:
-        # kill everything if we can't get confirmation
-        end_processes(acquisition_loops, writers, [])
-        return save_location, video_file_name, final_config
+        arduino.write(msg)
+
+        # Listen for confirmation from arduino that we're going, abort if not 
+        try:
+            confirmation = wait_for_serial_confirmation(
+                arduino, expected_confirmation="Start", seconds_to_wait=10
+            )
+        except:
+            # kill everything if we can't get confirmation
+            end_processes(acquisition_loops, writers, [])
+            return save_location, video_file_name, final_config
 
     # Wait for the specified duration
-    finished = False
     try:
         pbar = tqdm(total=recording_duration_s, desc="recording progress (s)")
         # how long to record
         datetime_prev = datetime.now()
-        endtime = datetime_prev + timedelta(seconds=recording_duration_s + 10)
+        time_to_wait = recording_duration_s + 10 if final_config["globals"]["arduino_required"] else recording_duration_s
+        endtime = datetime_prev + timedelta(seconds=time_to_wait)
         while datetime.now() < endtime:
 
-            # Check for the arduino to say we're done
-            msg = arduino.readline().decode("utf-8").strip("\r\n")
-            if len(msg) > 0:
-                print(msg)
-                # TODO: save trigger data
-            if msg == "Finished":
-                print("Finished recieved from arduino")
-                finished = True
-                break
+            if final_config["globals"]["arduino_required"]:
+                # Check for the arduino to say we're done
+                msg = arduino.readline().decode("utf-8").strip("\r\n")
+                if len(msg) > 0:
+                    print(msg)
+                    # TODO: save trigger data
+                if msg == "Finished":
+                    print("Finished recieved from arduino")
+                    break
 
             # Update pbar
             if (datetime.now() - datetime_prev).seconds > 0:
                 pbar.update((datetime.now() - datetime_prev).seconds)
                 datetime_prev = datetime.now()
-
-        # If Python finishes first, wait a moment for the arduino to finish
-        if not finished:
-            try:
-                confirmation = wait_for_serial_confirmation(
-                    arduino, expected_confirmation="Finished", seconds_to_wait=10
-                )
-            except ValueError as e:
-                print(e)
-
-    except (KeyboardInterrupt) as e:
-        pass
 
     finally:
         # End the processes and close the arduino regardless
@@ -556,7 +552,8 @@ def refactor_acquire_video(
         pbar.update((datetime.now() - datetime_prev).seconds)
         pbar.close()
         print("Ending processes, this may take a moment...")
-        arduino.close()
+        if final_config["globals"]["arduino_required"]:
+            arduino.close()
         end_processes(acquisition_loops, writers, None, writer_timeout=300)
         print("Done.")
 

--- a/multicamera_acquisition/acquisition.py
+++ b/multicamera_acquisition/acquisition.py
@@ -124,7 +124,6 @@ class AcquisitionLoop(mp.Process):
         # Then just add the device index to the config and allow the cameras to directly
         # receive a device index.
         cam = get_camera(
-            self.fps,
             brand=self.camera_config["brand"],
             id=self.camera_config["id"],
             name=self.camera_config["name"],

--- a/multicamera_acquisition/config/config.py
+++ b/multicamera_acquisition/config/config.py
@@ -112,18 +112,13 @@ def validate_recording_config(recording_config):
         if recording_config["cameras"][camera_name]["brand"] not in ["basler", "basler_emulated", "azure"]:
             raise ValueError(f"Unsupported camera brand: {recording_config['cameras'][camera_name]['brand']}")
 
-    # Ensure that each IR camera has the same FPS
-    all_fps = []
+    # Warn user that fps for baslers / azures is deprecated
     for camera_name in recording_config["cameras"].keys():
-        if recording_config["cameras"][camera_name]["brand"] in ["basler", "basler_emulated"]:
-            all_fps.append(recording_config["cameras"][camera_name]["fps"])
-    if len(set(all_fps)) > 1:
-        raise ValueError("All IR cameras must have the same FPS")
-    else: 
-        fps = all_fps[0]
+        if "fps" in recording_config["cameras"][camera_name].keys():
+            print("WARNING: fps is deprecated for Basler camera configs (unecessary) and azure cameras (only 30 fps supported).")
 
     # Ensure that the requested frame rate is a multiple of the azure's 30 fps rate
-    if fps % 30 != 0:
+    if recording_config["globals"]["fps"] % 30 != 0:
         raise ValueError("Framerate must be a multiple of the Azure's frame rate (30)")
 
     # Ensure that the requested frame rate is a multiple of the display frame rate

--- a/multicamera_acquisition/interfaces/camera_base.py
+++ b/multicamera_acquisition/interfaces/camera_base.py
@@ -8,14 +8,19 @@ class CameraError(Exception):
 
 
 def get_camera(
-    brand="flir",
+    fps,
+    brand="basler",
     id=0,
     name=None,
     config=None,
 ):
     """Get a camera object.
+
     Parameters
     ----------
+    fps : int
+        The desired frame rate for the camera.
+
     brand : string (default: 'flir')
         The brand of camera to use.  Currently only 'flir' is supported. If
         'flir', the software PySpin is used. if 'basler', the software pypylon

--- a/multicamera_acquisition/interfaces/camera_base.py
+++ b/multicamera_acquisition/interfaces/camera_base.py
@@ -8,7 +8,6 @@ class CameraError(Exception):
 
 
 def get_camera(
-    fps,
     brand="basler",
     id=0,
     name=None,

--- a/multicamera_acquisition/interfaces/config.py
+++ b/multicamera_acquisition/interfaces/config.py
@@ -11,6 +11,7 @@ ALL_CAM_PARAMS = [
     "exposure_time",
     "display",
     "gain",
+    "fps",
 ]
 
 ALL_WRITER_PARAMS = [
@@ -49,7 +50,7 @@ for pair in itertools.combinations(
     assert all([param not in pair[1] for param in pair[0]]), f"Redundant param names: {pair}"
 
 
-def partial_config_from_camera_list(camera_list, fps):
+def partial_config_from_camera_list(camera_list):
     """ Create a partial recording config from a list of camera dicts.
 
     Parameters
@@ -70,9 +71,6 @@ def partial_config_from_camera_list(camera_list, fps):
                 Whether to display the camera's feed in real-time.
             gain: int
                 The gain for the camera, in (units?). (TODO: valid ranges?)
-
-    fps : int
-        The desired frame rate for the recording.
 
         Other optional parameters depend on the camera brand. It is also possible to control the Writer parameters for each camera. The syntax is 
         flat (not nested) and follows the same rules as the camera params. For example, to set
@@ -105,20 +103,19 @@ def partial_config_from_camera_list(camera_list, fps):
             elif key in ALL_TRIGGER_PARAMS:
                 partial_config["cameras"][camera_name]["trigger"][key] = camera_dict[key]
 
-        # Add fps to this camera
-        # NB: we don't allow the user to specify fps per camera, since it's a global param
-        partial_config["cameras"][camera_name]["fps"] = fps
-
     return partial_config
 
 
-def create_full_camera_default_config(partial_config):
+def create_full_camera_default_config(partial_config, fps):
     """Create a full, default recording config for the cameras + writers.
 
     Parameters
     ----------
     partial_config : dict
         A partial config for cameras + their writers, generated from any user input.
+
+    fps : int
+        The desired fps for the recordings.
 
     Returns
     -------
@@ -135,8 +132,8 @@ def create_full_camera_default_config(partial_config):
     assert len(set(camera_names)) == len(camera_names), "Duplicate camera names found in config"
 
     for camera_name in camera_names:
-        fps = partial_config["cameras"][camera_name]["fps"]
 
+        # Create what will become the full config for this camera
         cam_config = {}
         cam_config["name"] = camera_name
 
@@ -149,16 +146,16 @@ def create_full_camera_default_config(partial_config):
 
         # Find the correct defaults (both camera and writer configs)
         if cam_config["brand"] == "basler":
-            default_cam_conf = BaslerCamera.default_camera_config(fps)
+            default_cam_conf = BaslerCamera.default_camera_config()
             default_writer_conf = BaslerCamera.default_writer_config(fps)
             defaults = {**default_cam_conf, "writer": default_writer_conf}
         elif cam_config["brand"] == "basler_emulated":
-            default_cam_conf = EmulatedBaslerCamera.default_camera_config(fps)
+            default_cam_conf = EmulatedBaslerCamera.default_camera_config()
             default_writer_conf = EmulatedBaslerCamera.default_writer_config(fps)
             defaults = {**default_cam_conf, "writer": default_writer_conf}
         elif cam_config["brand"] == "azure":
             default_cam_conf = AzureCamera.default_config()
-            default_writer_conf = AzureCamera.default_writer_config()
+            default_writer_conf = AzureCamera.default_writer_config(30)  # TODO: un-hardcode this even tho it wont change
             defaults = {**default_cam_conf, "writer": default_writer_conf}
         else:
             raise NotImplementedError

--- a/multicamera_acquisition/tests/acquisition/test_acq_video.py
+++ b/multicamera_acquisition/tests/acquisition/test_acq_video.py
@@ -36,12 +36,19 @@ def trigger_type(pytestconfig):
     return pytestconfig.getoption("trigger_type")  # default continuous (ie no trigger required), see conftest.py
 
 
-def test_refactor_acquire_video(tmp_path, camera_brand, n_test_frames, trigger_type, fps):
+@pytest.fixture(scope="session")
+def writer_type(pytestconfig):
+    return pytestconfig.getoption("writer_type")  # default nvc, see conftest.py
+
+
+def test_refactor_acquire_video(tmp_path, camera_brand, n_test_frames, trigger_type, writer_type, fps):
 
     camera_list = [
         {"name": "top", "brand": camera_brand, "id": 0},
         {"name": "bottom", "brand": camera_brand, "id": 1}
     ]
+
+    print(f"trigger tpye: {trigger_type}")
 
     # Set the trigger behavior
     if trigger_type == "continuous":
@@ -52,29 +59,34 @@ def test_refactor_acquire_video(tmp_path, camera_brand, n_test_frames, trigger_t
         camera["short_name"] = short_name
 
     # Parse the "camera list" into a partial config
-    partial_new_config = partial_config_from_camera_list(camera_list, fps)
+    partial_new_config = partial_config_from_camera_list(camera_list)
 
-    # Add ffmpeg writers to each camera
-    # TODO: allow this to be nvc dynamically for testing. 
-    # writer_config = FFMPEG_Writer.default_writer_config(fps)
-    writer_config = NVC_Writer.default_writer_config(fps)
+    # Add writer configs to each camera config
+    if writer_type == "nvc":
+        writer_config = NVC_Writer.default_writer_config(fps)
+    elif writer_type == "ffmpeg":
+        writer_config = FFMPEG_Writer.default_writer_config(fps)
+
     for camera_name in partial_new_config["cameras"].keys():
         writer_config["camera_name"] = camera_name
         partial_new_config["cameras"][camera_name]["writer"] = writer_config
 
     # Create the full config, filling in defaults where necessary
-    full_config = create_full_camera_default_config(partial_new_config)
+    full_config = create_full_camera_default_config(partial_new_config, fps)
+    full_config["globals"] = {}
+    full_config["globals"]["fps"] = fps
+    full_config["globals"]["arduino_required"] = (trigger_type == "arduino")
 
     # Set up the acquisition loop part of the config
     acq_config = AcquisitionLoop.default_acq_loop_config()
-    acq_config["max_frames_to_acqure"] = int(n_test_frames)
+    acq_config["max_frames_to_acqure"] = n_test_frames
     full_config["acq_loop"] = acq_config
 
     # Run the func!
     save_loc, first_video_file_name, full_config = refactor_acquire_video(
         tmp_path,
         full_config,
-        recording_duration_s=(int(n_test_frames) / fps),
+        recording_duration_s=int(n_test_frames / fps),
         append_datetime=True,
         overwrite=False,
     )
@@ -86,10 +98,16 @@ def test_refactor_acquire_video(tmp_path, camera_brand, n_test_frames, trigger_t
 
     # Check that the video has the right number of frames
     for camera_name in full_config["cameras"].keys():
-        assert count_frames(str(first_video_file_name)) == (int(n_test_frames))
+        assert count_frames(str(first_video_file_name)) == n_test_frames
 
 
 def test_refactor_acquire_video_multiple_vids_muxing(tmp_path, camera_brand, n_test_frames, trigger_type, fps):
+
+    try:
+        import PyNvCodec as nvc
+    except ImportError:
+        pytest.skip("PyNvCodec not installed, skipping muxing test")
+
     camera_list = [
         {"name": "top", "brand": camera_brand, "id": 0},
         {"name": "bottom", "brand": camera_brand, "id": 1}
@@ -104,32 +122,36 @@ def test_refactor_acquire_video_multiple_vids_muxing(tmp_path, camera_brand, n_t
         camera["short_name"] = short_name
 
     # Parse the "camera list" into a partial config
-    partial_new_config = partial_config_from_camera_list(camera_list, fps)
+    partial_new_config = partial_config_from_camera_list(camera_list)
 
     # Add NVC writers to each camera
     nvc_writer_config = NVC_Writer.default_writer_config(fps)
     nvc_writer_config["auto_remux_videos"] = True  # this is the default, but just to make it explicit / in case we change the default
-    
+
     # KEY LINE FOR THIS TEST
-    nvc_writer_config["max_video_frames"] = int(int(n_test_frames) / 2)
+    assert n_test_frames % 2 == 0
+    nvc_writer_config["max_video_frames"] = int(n_test_frames / 2)
 
     for camera_name in partial_new_config["cameras"].keys():
         nvc_writer_config["camera_name"] = camera_name
         partial_new_config["cameras"][camera_name]["writer"] = nvc_writer_config
 
     # Create the full config, filling in defaults where necessary
-    full_config = create_full_camera_default_config(partial_new_config)
+    full_config = create_full_camera_default_config(partial_new_config, fps)
+    full_config["globals"] = {}
+    full_config["globals"]["fps"] = fps
+    full_config["globals"]["arduino_required"] = (trigger_type == "arduino")
 
     # Set up the acquisition loop part of the config
     acq_config = AcquisitionLoop.default_acq_loop_config()
-    acq_config["max_frames_to_acqure"] = int(n_test_frames)
+    acq_config["max_frames_to_acqure"] = n_test_frames
     full_config["acq_loop"] = acq_config
 
     # Run the func!
     save_loc, first_video_file_name, full_config = refactor_acquire_video(
         tmp_path,
         full_config,
-        recording_duration_s=(int(n_test_frames) / fps),
+        recording_duration_s=(n_test_frames / fps),
         append_datetime=True,
         overwrite=False,
     )
@@ -149,12 +171,17 @@ def test_refactor_acquire_video_multiple_vids_muxing(tmp_path, camera_brand, n_t
     # Check that the video has the right number of frames
     # NB: this won't work unless we mux the videos, so this also tests the muxing.
     for camera_name in full_config["cameras"].keys():
-        # assert count_frames(str(first_video_file_name)) == int(n_test_frames)/2
-        assert count_frames(str(next_video_file_name)) == int(n_test_frames)/2
-
+        assert count_frames(str(first_video_file_name)) == n_test_frames/2
+        assert count_frames(str(next_video_file_name)) == n_test_frames/2
 
 
 def test_refactor_acquire_video_muxing(tmp_path, camera_brand, n_test_frames, trigger_type, fps):
+
+    try:
+        import PyNvCodec as nvc
+    except ImportError:
+        pytest.skip("PyNvCodec not installed, skipping muxing test")
+
     camera_list = [
         {"name": "top", "brand": camera_brand, "id": 0},
         {"name": "bottom", "brand": camera_brand, "id": 1}
@@ -169,7 +196,7 @@ def test_refactor_acquire_video_muxing(tmp_path, camera_brand, n_test_frames, tr
         camera["short_name"] = short_name
 
     # Parse the "camera list" into a partial config
-    partial_new_config = partial_config_from_camera_list(camera_list, fps)
+    partial_new_config = partial_config_from_camera_list(camera_list)
 
     # Add NVC writers to each camera
     nvc_writer_config = NVC_Writer.default_writer_config(fps)
@@ -179,18 +206,21 @@ def test_refactor_acquire_video_muxing(tmp_path, camera_brand, n_test_frames, tr
         partial_new_config["cameras"][camera_name]["writer"] = nvc_writer_config
 
     # Create the full config, filling in defaults where necessary
-    full_config = create_full_camera_default_config(partial_new_config)
+    full_config = create_full_camera_default_config(partial_new_config, fps)
+    full_config["globals"] = {}
+    full_config["globals"]["fps"] = fps
+    full_config["globals"]["arduino_required"] = (trigger_type == "arduino")
 
     # Set up the acquisition loop part of the config
     acq_config = AcquisitionLoop.default_acq_loop_config()
-    acq_config["max_frames_to_acqure"] = int(n_test_frames)
+    acq_config["max_frames_to_acqure"] = n_test_frames
     full_config["acq_loop"] = acq_config
 
     # Run the func!
     save_loc, first_video_file_name, full_config = refactor_acquire_video(
         tmp_path,
         full_config,
-        recording_duration_s=(int(n_test_frames) / fps),
+        recording_duration_s=int(n_test_frames / fps),
         append_datetime=True,
         overwrite=False,
     )
@@ -203,4 +233,4 @@ def test_refactor_acquire_video_muxing(tmp_path, camera_brand, n_test_frames, tr
     # Check that the video has the right number of frames
     # NB: this won't work unless we mux the videos, so this also tests the muxing.
     for camera_name in full_config["cameras"].keys():
-        assert count_frames(str(first_video_file_name)) == int(n_test_frames)
+        assert count_frames(str(first_video_file_name)) == n_test_frames

--- a/multicamera_acquisition/tests/conftest.py
+++ b/multicamera_acquisition/tests/conftest.py
@@ -18,3 +18,15 @@ def pytest_addoption(parser):
         action="store",
         default="continuous",
     )
+
+    parser.addoption(
+        "--writer_type",
+        action="store",
+        default="nvc",
+    )
+
+    parser.addoption(
+        "--fps",
+        action="store",
+        default=30,
+    )

--- a/multicamera_acquisition/tests/interfaces/test_ir_cameras.py
+++ b/multicamera_acquisition/tests/interfaces/test_ir_cameras.py
@@ -42,15 +42,15 @@ def fps(pytestconfig):
         >>> pytest ./path/to/test_camera_basler.py --camera_type basler_emulated
         >>> pytest ./path/to/test_camera_basler.py --camera_type basler_camera
     """
-    return pytestconfig.getoption("fps", default=30)
+    return int(pytestconfig.getoption("fps"))
 
 
 @pytest.fixture(scope="function")
 def camera(camera_type, fps):
     if camera_type == 'basler_camera':
-        cam = BaslerCamera(id=0, fps=fps)
+        cam = BaslerCamera(id=0)
     elif camera_type == 'basler_emulated':
-        cam = EmulatedBaslerCamera(id=0, fps=fps)
+        cam = EmulatedBaslerCamera(id=0)
     else:
         raise ValueError("Invalid camera type")
 
@@ -78,20 +78,23 @@ class Test_Camera_InitAndStart():
 class Test_OpenMultipleCameras():
     """Test how we open multiple cameras so they don't interfere
     """
-    def test_two_cameras(self, fps):
+    def test_two_cameras(self, fps, camera_type):
+
+        if camera_type == 'basler_camera':
+            CamClass = BaslerCamera
+        elif camera_type == 'basler_emulated':
+            CamClass = EmulatedBaslerCamera
+
         # should default to 0
-        cam1 = BaslerCamera(id=0, fps=fps)
-        cam2 = BaslerCamera(id=1, fps=fps)
+        cam1 = CamClass(id=0)
+        cam2 = CamClass(id=1)
         cam1.init()
         cam2.init()
-        # cam1.start()
-        # cam2.start()
-        # img1 = cam1.get_array(timeout=1000)
-        # img2 = cam2.get_array(timeout=1000)
-        # assert isinstance(img1, np.ndarray)
-        # assert isinstance(img2, np.ndarray)
-        # cam1.stop()
-        # cam2.stop()
+        cam1.start()
+        cam2.start()
+
+        cam1.stop()
+        cam2.stop()
         cam1.close()
         cam2.close()
 
@@ -101,7 +104,7 @@ class Test_CameraIDMethods():
     """
     def test_default_device_index(self, fps):
         # should default to 0
-        cam = BaslerCamera(fps=fps)
+        cam = BaslerCamera()
         cam.init()
         assert cam.device_index == 0
         cam.close()
@@ -109,13 +112,13 @@ class Test_CameraIDMethods():
     @pytest.mark.parametrize("id", [0, 1])
     def test_set_device_index(self, id, camera_type):
         if camera_type == 'basler_camera':
-            cam = BaslerCamera(id=id, fps=fps)
+            cam = BaslerCamera(id=id)
         elif camera_type == 'basler_emulated':
-            cam = EmulatedBaslerCamera(id=id, fps=fps)
+            cam = EmulatedBaslerCamera(id=id)
         cam.init()
         assert cam.device_index == id
         cam.close()
 
     def test_id_errs(self):
         with pytest.raises(CameraError):
-            _ = BaslerCamera(id="abc", fps=fps)  # no cam with this sn should exist
+            _ = BaslerCamera(id="abc")  # no cam with this sn should exist

--- a/multicamera_acquisition/tests/writer/test_writers.py
+++ b/multicamera_acquisition/tests/writer/test_writers.py
@@ -13,25 +13,16 @@ from multicamera_acquisition.writer import FFMPEG_Writer
 
 from multicamera_acquisition.video_utils import count_frames
 
-
-@pytest.fixture(scope="session")
-def fps(pytestconfig):
-    """A session-wide fixture to return the desired fps.
-
-    See test_cameras.py::camera for possible camera options.
-
-    Example usage:
-        >>> pytest ./path/to/test_camera_basler.py --camera_type basler_emulated
-        >>> pytest ./path/to/test_camera_basler.py --camera_type basler_camera
-    """
-    return pytestconfig.getoption("fps", default=30)
+from multicamera_acquisition.tests.interfaces.test_ir_cameras import (
+    fps,
+)
 
 
 @pytest.fixture(scope="session")
 def n_test_frames(pytestconfig):
     """A session-wide fixture to return the desired number of test frames per movie.
     """
-    return pytestconfig.getoption("n_test_frames", default=200)
+    return int(pytestconfig.getoption("n_test_frames"))
 
 
 def dummy_frames_func(fps, queue, n_test_frames):
@@ -75,6 +66,13 @@ def nvc_writer_processes(tmp_path, fps, n_test_frames):
 
 
 def test_NVC_writer(nvc_writer_processes, n_test_frames):
+
+    # Make sure NVC is installed, else report test not run
+    try:
+        import PyNvCodec as nvc
+    except ImportError:
+        pytest.skip("PyNvCodec not installed, skipping NVC_Writer test")
+
 
     # Get the writer and dummy frames proc
     writer, dummy_frames_proc = nvc_writer_processes


### PR DESCRIPTION
-- Basler camera now doesn't require fps param since it doesn't do anything
-- fps is a global config param which is passed to the writers + acq loop directly.