### PR TITLE
support for color cameras

### DIFF
--- a/multicamera_acquisition/interfaces/camera_basler.py
+++ b/multicamera_acquisition/interfaces/camera_basler.py
@@ -234,11 +234,7 @@ class BaslerCamera(BaseCamera):
             - self.model_name: the model name of the camera (self.cam.GetDeviceInfo().GetModelName())
         """
         di = pylon.DeviceInfo()
-        devices = self.system.EnumerateDevices(
-            [
-                di,
-            ]
-        )
+        devices = self.system.EnumerateDevices([di])
 
         try:
             self.cam = pylon.InstantCamera(
@@ -445,9 +441,6 @@ class BaslerCamera(BaseCamera):
 
         if img.GrabSucceeded():
             img_array = img.Array.astype(np.uint8)
-            if self.config["pixel_format"] == "BayerRG8":
-                img_array = cv2.cvtColor(img_array, cv2.COLOR_BAYER_RG2RGB)
-
             if get_linestatus:
                 line_status = img.ChunkLineStatusAll.Value
             if get_timestamp:

--- a/multicamera_acquisition/interfaces/config.py
+++ b/multicamera_acquisition/interfaces/config.py
@@ -13,6 +13,7 @@ ALL_CAM_PARAMS = [
     "roi",
     "gain",
     "gamma",
+    "pixel_format",
     "exposure",
     "brand",
     "fps",

--- a/multicamera_acquisition/writer.py
+++ b/multicamera_acquisition/writer.py
@@ -272,7 +272,6 @@ class NVC_Writer(BaseWriter):
             "max_video_frames": None,  # None means no limit; otherwise, pass an int
             "auto_remux_videos": True,
             # encoder params
-            "pixel_format": "gray8",
             "preset": "P1",  # P1 fastest, P7 slowest / x = set(('apple', 'banana', 'cherry'))
             "codec": "h264",  # h264, hevc
             "profile": "high",  # high or baseline (?)
@@ -291,13 +290,7 @@ class NVC_Writer(BaseWriter):
         return config
 
     def validate_config(self):
-        # Check pixel format (only gray8 supported by VPF)
-        assert (
-            "pixel_format" in self.config
-        ), "VPF requires pixel_format to be specified"
-        assert (
-            self.config["pixel_format"] == "gray8"
-        ), "VPF only supports gray8 pixel format"
+        pass
 
     def _get_new_pipe(self, data_shape):
 

--- a/multicamera_acquisition/writer.py
+++ b/multicamera_acquisition/writer.py
@@ -296,7 +296,7 @@ class NVC_Writer(BaseWriter):
         if vid_type == "ir":
             config["pixel_format"] = "gray8"
         elif vid_type == "color":
-            config["pixel_format"] = "rgb8"
+            config["pixel_format"] = "yuv444"
         return config
 
     def validate_config(self):
@@ -306,8 +306,8 @@ class NVC_Writer(BaseWriter):
         ), "VPF requires pixel_format to be specified"
         assert self.config["pixel_format"] in [
             "gray8",
-            "rgb8",
-        ], "VPF only supports gray8 or rgb8 pixel format"
+            "yuv444",
+        ], "VPF only supports gray8 or yuv444 pixel format"
 
     def _get_new_pipe(self, data_shape):
 
@@ -338,7 +338,7 @@ class NVC_Writer(BaseWriter):
 
         if self.config["pixel_format"] == "gray8":
             pixel_format = nvc.PixelFormat.NV12
-        elif self.config["pixel_format"] == "rgb8":
+        elif self.config["pixel_format"] == "yuv444":
             pixel_format = nvc.PixelFormat.YUV444
 
         self.logger.debug(f"Created new pipe with encoder dict ({encoder_dictionary}")
@@ -366,7 +366,7 @@ class NVC_Writer(BaseWriter):
                 nv12_array[: self.img_dims[0], : self.img_dims[1]] = data
             img_array = nv12_array
 
-        elif self.config["pixel_format"] == "rgb8":
+        elif self.config["pixel_format"] == "yuv444":
             img_array = cv2.cvtColor(data, cv2.COLOR_RGB2YUV)
 
         try:


### PR DESCRIPTION
Tested on Ubuntu 22 with Basler ace2 a2A1920-160ucBAS Color USB3 Basic Camera using software trigger. 

Note that BayerRG8 pixel_format leads to high CPU usage, so RGB8 should ideally be used. 